### PR TITLE
Normalize CI/CD workflows

### DIFF
--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@f0ba95798ab73202b3f2812ea0209db07d99c6e8 # v4.9.41
     secrets: inherit

--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -1,15 +1,17 @@
-# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: 'Dependabot auto approval'
 
 on:
-  pull_request_target
+  pull_request_target:
+
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
-  package:
-    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@f0ba95798ab73202b3f2812ea0209db07d99c6e8 # v4.9.41
+  approve:
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -8,6 +8,9 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   release:
     uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@766cd1914571123cc26ab6e0f1782c784dc4f11f # v4.4.28

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: Auto Relase
+name: 'Auto Release'
 
 on:
   schedule: # Run every day at 12:00 UTC
@@ -13,5 +13,6 @@ permissions:
 
 jobs:
   release:
-    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@766cd1914571123cc26ab6e0f1782c784dc4f11f # v4.4.28
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+  contents: write
+  packages: write
+
 jobs:
   ci:
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@766cd1914571123cc26ab6e0f1782c784dc4f11f # v4.4.28

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ permissions:
 
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@766cd1914571123cc26ab6e0f1782c784dc4f11f # v4.4.28
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
       release-type:   library
       yaml-lint-skip: false

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,7 +11,12 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@60838be4a68ca029af165c3d9067aa41f4e8db14 # v4.9.41
     secrets: inherit

--- a/.github/workflows/proj.yml
+++ b/.github/workflows/proj.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: 'PROJ: xmidt-team'
@@ -17,6 +17,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  package:
-    uses: xmidt-org/shared-go/.github/workflows/proj.yml@60838be4a68ca029af165c3d9067aa41f4e8db14 # v4.9.41
+  proj:
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit


### PR DESCRIPTION
## Summary

This PR normalizes the CI/CD workflows to align with the xmidt-org ideal state as outlined in issue #43.

## Changes

- Renamed `dependabot-approver.yml` to `approve-dependabot.yml`
- Updated `approve-dependabot.yml` to reference `xmidt-org/shared-go/.github/workflows/approve-dependabot.yml` with SHA pin (f0ba95798ab73202b3f2812ea0209db07d99c6e8 - v4.9.41)
- Updated `proj-xmidt-team.yml` to reference `xmidt-org/shared-go/.github/workflows/proj.yml` with SHA pin (60838be4a68ca029af165c3d9067aa41f4e8db14 - v4.9.41)
- Added required permissions block to `ci.yml` (pull-requests: read, contents: write, packages: write)
- Added required permissions block to `auto-releaser.yml` (contents: write)
- Added required permissions block to `proj-xmidt-team.yml` (contents: read, issues: write, pull-requests: write)

Resolves #43